### PR TITLE
Make jruby-elasticsearch compatible with the new ES 0.19 namespace change.

### DIFF
--- a/lib/jruby-elasticsearch/searchrequest.rb
+++ b/lib/jruby-elasticsearch/searchrequest.rb
@@ -13,7 +13,12 @@ class ElasticSearch::SearchRequest < ElasticSearch::Request
   public
   def initialize(client)
     @client = client
-    @prep = org.elasticsearch.action.search.SearchRequestBuilder.new(@client)
+    begin
+      @prep = org.elasticsearch.client.action.search.SearchRequestBuilder.new(@client)
+    rescue NameError
+      # The 'client' namespace was removed in elasticsearch 0.19.0
+      @prep = org.elasticsearch.action.search.SearchRequestBuilder.new(@client)
+    end
     @indeces = []
     super()
   end # def initialize

--- a/lib/jruby-elasticsearch/searchrequest.rb
+++ b/lib/jruby-elasticsearch/searchrequest.rb
@@ -13,7 +13,7 @@ class ElasticSearch::SearchRequest < ElasticSearch::Request
   public
   def initialize(client)
     @client = client
-    @prep = org.elasticsearch.client.action.search.SearchRequestBuilder.new(@client)
+    @prep = org.elasticsearch.action.search.SearchRequestBuilder.new(@client)
     @indeces = []
     super()
   end # def initialize


### PR DESCRIPTION
This should make the jruby-elasticsearch gem compatible with ES 0.19, keeping compatibility with 0.18.
