### PR TITLE
added network.publish_host elasticsearch option

### DIFF
--- a/lib/jruby-elasticsearch/client.rb
+++ b/lib/jruby-elasticsearch/client.rb
@@ -53,6 +53,10 @@ class ElasticSearch::Client
         builder.settings.put('network.host', options[:bind_host])
       end
 
+      if options[:publish_host]
+        builder.settings.put('network.publish_host', options[:publish_host])
+      end
+
       if options[:node_name]
         builder.settings.put('node.name', options[:node_name])
       end


### PR DESCRIPTION
Hello,

I suggest to add publish_host option to the library and consequently to logstash.
Since many people are struggling with firewall issue when using custom elasticsearch configurations.

As it's said in the Logstash documentation ports 9300:9400 must be open. Indeed in my case they were open but on the different network. Finally i cleared firewall and understood that unicast discovery fails just because logstash elasticsearch publishes itself on different network...

Best,
Denis
